### PR TITLE
Modify argmax tie-breaker

### DIFF
--- a/trab1.s
+++ b/trab1.s
@@ -752,7 +752,7 @@ argmax_loop:
     add t1, s0, t0          # Endereço vec[i]
     lb t5, 0(t1)            # vec[i]
     
-    ble t5, t4, next_iter   # vec[i] <= max_val
+    blt t5, t4, next_iter   # vec[i] < max_val
     
     mv t3, t0               # max_idx = i
     mv t4, t5               # max_val = vec[i]


### PR DESCRIPTION
## Summary
- adjust argmax to update index on `>=` rather than strictly greater

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d868761608321a449a9611cc03ec0